### PR TITLE
fix: align env variable name with all blueprints

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,23 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": false,
+  "objectWrap": "preserve",
+  "bracketSpacing": true,
+  "semi": true,
+  "experimentalOperatorPosition": "end",
+  "experimentalTernaries": false,
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "quoteProps": "as-needed",
+  "trailingComma": "all",
+  "singleAttributePerLine": false,
+  "htmlWhitespaceSensitivity": "css",
+  "vueIndentScriptAndStyle": false,
+  "proseWrap": "preserve",
+  "insertPragma": false,
+  "printWidth": 80,
+  "requirePragma": false,
+  "tabWidth": 2,
+  "useTabs": true,
+  "embeddedLanguageFormatting": "auto"
+}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install
 In the root of the project, create a `.env` file to store the Storyblok access token:
 
 ```sh
-VITE_STORYBLOK_DELIVERY_API_TOKEN=<REPLACE_WITH_YOUR_TOKEN>
+STORYBLOK_DELIVERY_API_TOKEN=<REPLACE_WITH_YOUR_TOKEN>
 ```
 
 > [!IMPORTANT]

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,13 +12,13 @@ import Feature from './storyblok/Feature';
 import Grid from './storyblok/Grid';
 
 storyblokInit({
-	accessToken: import.meta.env.VITE_STORYBLOK_DELIVERY_API_TOKEN,
+	accessToken: import.meta.env.STORYBLOK_DELIVERY_API_TOKEN,
 	apiOptions: {
 		/** Set the correct region for your space. Learn more: https://www.storyblok.com/docs/packages/storyblok-js */
 		region: 'eu',
 		/** The following code is only required when creating a Storyblok space directly via the Blueprints feature. */
-		endpoint: import.meta.env.VITE_STORYBLOK_API_BASE_URL
-			? `${new URL(import.meta.env.VITE_STORYBLOK_API_BASE_URL).origin}/v2`
+		endpoint: import.meta.env.STORYBLOK_API_BASE_URL
+			? `${new URL(import.meta.env.STORYBLOK_API_BASE_URL).origin}/v2`
 			: undefined,
 	},
 	use: [apiPlugin],

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,19 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import mkcert from 'vite-plugin-mkcert';
 
 // https://vite.dev/config/
-export default defineConfig({
-	plugins: [react(), mkcert()],
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, process.cwd(), '');
+	return {
+		plugins: [react(), mkcert()],
+		define: {
+			'import.meta.env.STORYBLOK_DELIVERY_API_TOKEN': JSON.stringify(
+				env.STORYBLOK_DELIVERY_API_TOKEN,
+			),
+			'import.meta.env.STORYBLOK_API_BASE_URL': JSON.stringify(
+				env.STORYBLOK_API_BASE_URL,
+			),
+		},
+	};
 });


### PR DESCRIPTION
Change env variable name from `VITE_STORYBLOK_DELIVERY_API_TOKEN` to `STORYBLOK_DELIVERY_API_TOKEN`